### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gameenderalse.cpp
+++ b/src/gameenderalse.cpp
@@ -134,7 +134,7 @@ QString GameEnderalSE::description() const
 
 MOBase::VersionInfo GameEnderalSE::version() const
 {
-  return VersionInfo(1, 0, 0, VersionInfo::RELEASE_BETA);
+  return VersionInfo(1, 1, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameEnderalSE::settings() const

--- a/src/gameenderalse.cpp
+++ b/src/gameenderalse.cpp
@@ -146,7 +146,6 @@ void GameEnderalSE::initializeProfile(const QDir &path, ProfileSettings settings
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Enderal Special Edition", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Enderal Special Edition", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {
@@ -282,4 +281,3 @@ MappingType GameEnderalSE::mappings() const
 
   return result;
 }
-


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.